### PR TITLE
Update Melpa URL

### DIFF
--- a/init.el
+++ b/init.el
@@ -13,7 +13,7 @@
 
 (require 'package)
 (add-to-list 'package-archives
-             '("melpa" . "http://melpa.milkbox.net/packages/") t)
+             '("melpa" . "http://melpa.org/packages/") t)
 
 (package-initialize)
 (when (not package-archive-contents)


### PR DESCRIPTION
MELPA is no longer accessible from the old milkbox.net URL